### PR TITLE
Fix SteamNetworkingUtils crash without any message

### DIFF
--- a/src/coplay.h
+++ b/src/coplay.h
@@ -27,7 +27,7 @@
 #define COPLAY_MAX_PACKETS 16
 
 //YYYY-MM-DD-(a-z) if theres multiple in a day
-#define COPLAY_VERSION "2024-07-26-a"
+#define COPLAY_VERSION "2024-09-03-a"
 
 //For vpcless quick testing, leave this commented when commiting
 //#define COPLAY_USE_LOBBIES
@@ -186,8 +186,12 @@ public:
             Error("SDLNet Failed to Initialize: \"%s\"", SDLNet_GetError());
         }
 
-        SteamNetworkingUtils()->InitRelayNetworkAccess();
-
+		if (SteamNetworkingUtils()) 
+		{
+			SteamNetworkingUtils()->InitRelayNetworkAccess();
+		} else {
+			Error("Failed to Initialize Steam Networking. Make sure that you have Steam open.");
+		}
 
         g_pCoplayConnectionHandler = this;
         return true;


### PR DESCRIPTION
When Coplay on initialization tries to execute **InitRelayNetworkAccess** of **SteamNetworkingUtils** without Steam open, it crashes game without any error messages.

This pull request adds error message with explanation that the player needs to have Steam open to have multiplayer features working.
Alternatively, mod could still be launched without any error messages, but then Coplay has to reject any calls (and whats the point of MP mod launching without Steam connectivity lol)